### PR TITLE
Add information about valid timezone values

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -64,6 +64,7 @@ return [
     | Here you may specify the default timezone for your application, which
     | will be used by the PHP date and date-time functions. We have gone
     | ahead and set this to a sensible default for you out of the box.
+    | See https://www.php.net/manual/timezones.php for valid timezones.
     |
     */
 


### PR DESCRIPTION
I managed and am managing multiple Laravel instances over the years and still need to look every time for valid timezone values when I am about to configure this option. The default is "UTC" so most of the times I enter something like "UTC+1" to find out it doesn't work.

I think this additional link would save some minutes of searching and debugging which is a lot when it works for all people using Laravel (outside the UTC timezone).